### PR TITLE
[Fix] Fixed bug in JumpState's Execute function

### DIFF
--- a/Assets/UnityTechnologies/_DesignPatterns/5_State/Scripts/Pattern/SimpleStateMachine/States/JumpState.cs
+++ b/Assets/UnityTechnologies/_DesignPatterns/5_State/Scripts/Pattern/SimpleStateMachine/States/JumpState.cs
@@ -34,11 +34,11 @@ namespace DesignPatterns.StatePattern
             {
                 if (Mathf.Abs(player.CharController.velocity.x) > 0.1f || Mathf.Abs(player.CharController.velocity.z) > 0.1f)
                 {
-                    player.PlayerStateMachine.TransitionTo(player.PlayerStateMachine.idleState);
+                    player.PlayerStateMachine.TransitionTo(player.PlayerStateMachine.walkState);
                 }
                 else
                 {
-                    player.PlayerStateMachine.TransitionTo(player.PlayerStateMachine.walkState);
+                    player.PlayerStateMachine.TransitionTo(player.PlayerStateMachine.idleState);
                 }
             }
         }


### PR DESCRIPTION
# Fixed JumpState Bug
The state should transition to WalkState when the velocity value is greater than 0.1f, otherwise it should transition to IdleState.

## Before modification
### Simply jump in place
![jumpToIdle](https://github.com/user-attachments/assets/de203170-821a-420f-b12f-bddfc714f05d)
- Expected : JumpState -> IdleState
- Actual : JumpState -> WalkState -> IdleState

### When moving after landing
![jumpToWalk](https://github.com/user-attachments/assets/608d4e40-5187-4ec9-ae00-d5dd182f6ebd)
- Expected : JumpState -> WalkState
- Actual : JumpState -> IdleState -> WalkState

## After modification
### States transition correctly
![afterFix](https://github.com/user-attachments/assets/8f1ada6e-9c84-404a-91ee-1dfb2f26a679)